### PR TITLE
Add standalone mnemonic engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 regex = "1.11.1"
 walkdir = "2.5.0"
 
+
+[[bin]]
+name = "standalone"
+path = "src/bin/standalone.rs"

--- a/src/bin/standalone.rs
+++ b/src/bin/standalone.rs
@@ -1,0 +1,18 @@
+use lumeria::lumeria_loader::CapsuleLoader;
+use lumeria::mnemonic_engine::MnemonicEngine;
+
+fn main() {
+    println!("🧠 Loading capsules for standalone engine...");
+    let mut capsules = Vec::new();
+    for file in ["core0.lore", "grammar.lore", "core0.boot.assembly.lore"] {
+        let loader = CapsuleLoader::new(file);
+        capsules.extend(loader.load_capsules());
+    }
+    let recursive = CapsuleLoader::load_dir(".");
+    capsules.extend(recursive);
+
+    println!("✅ {} capsules loaded", capsules.len());
+
+    let mut engine = MnemonicEngine::new(capsules);
+    engine.emit("boot.assembly");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod lumeria_loader;
+pub mod lumeria_runtime;
+pub mod mnemonic_map;
+pub mod mnemonic_engine;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
-mod lumeria_loader;
-mod lumeria_runtime;
-
-use lumeria_loader::CapsuleLoader;
-use lumeria_runtime::LumeriaRuntime;
+use lumeria::lumeria_loader::CapsuleLoader;
+use lumeria::lumeria_runtime::LumeriaRuntime;
 
 fn main() {
     println!("🧠 Loading Lumeria system...");

--- a/src/mnemonic_engine.rs
+++ b/src/mnemonic_engine.rs
@@ -1,0 +1,61 @@
+use crate::lumeria_loader::Capsule;
+use crate::mnemonic_map::MnemonicMap;
+use std::collections::HashMap;
+
+pub struct MnemonicEngine {
+    capsules: Vec<Capsule>,
+    pub mnemonic: MnemonicMap,
+    trigger_map: HashMap<String, Vec<usize>>,
+}
+
+impl MnemonicEngine {
+    pub fn new(capsules: Vec<Capsule>) -> Self {
+        let mnemonic = MnemonicMap::from_capsules(&capsules);
+        let mut trigger_map: HashMap<String, Vec<usize>> = HashMap::new();
+        for (i, cap) in capsules.iter().enumerate() {
+            for trig in &cap.triggers {
+                trigger_map.entry(trig.clone()).or_default().push(i);
+            }
+        }
+        Self { capsules, mnemonic, trigger_map }
+    }
+
+    pub fn emit(&mut self, signal: &str) {
+        println!("\n🚨 emit: {}", signal);
+        if let Some(indices) = self.trigger_map.get(signal).cloned() {
+            for idx in indices {
+                let capsule = &self.capsules[idx];
+                println!("📦 {}", capsule.name);
+                let logic_blocks = capsule.logic.clone();
+                for logic in logic_blocks {
+                    self.execute_logic(&logic);
+                }
+            }
+        } else {
+            println!("⚠️ no capsule for {}", signal);
+        }
+    }
+
+    fn execute_logic(&mut self, logic: &str) {
+        for line in logic.lines() {
+            let line = line.trim();
+            if let Some(dir) = line.strip_prefix('>') {
+                let parts: Vec<_> = dir.splitn(2, ':').collect();
+                if parts.len() == 2 {
+                    let verb = parts[0].trim();
+                    let arg = parts[1].trim();
+                    if let Some(code) = self.mnemonic.resolve(verb) {
+                        println!("   {verb} ({code}) => {arg}");
+                        if verb == "emit" || verb == "emit.signal" {
+                            self.emit(arg);
+                        } else if verb == "log" {
+                            println!("{arg}");
+                        }
+                    } else {
+                        println!("   🚫 unknown verb: {verb}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/mnemonic_map.rs
+++ b/src/mnemonic_map.rs
@@ -1,0 +1,27 @@
+use crate::lumeria_loader::Capsule;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct MnemonicMap {
+    codes: HashMap<String, String>,
+}
+
+impl MnemonicMap {
+    pub fn from_capsules(capsules: &[Capsule]) -> Self {
+        let mut codes = HashMap::new();
+        for cap in capsules {
+            for (k, v) in &cap.mnemonic_map {
+                codes.insert(k.clone(), v.clone());
+            }
+        }
+        Self { codes }
+    }
+
+    pub fn resolve(&self, key: &str) -> Option<&str> {
+        self.codes.get(key).map(|s| s.as_str())
+    }
+
+    pub fn keys(&self) -> Vec<String> {
+        self.codes.keys().cloned().collect()
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `MnemonicEngine` and `MnemonicMap` for running capsules via mnemonic codes
- expose loader/runtime logic through a new library crate
- add `standalone` binary demonstrating a post-Rust mnemonic execution path

## Testing
- `cargo build --bin standalone`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68732190595c83319259a51fa7218432